### PR TITLE
get rid of retries

### DIFF
--- a/src/DatatypeChannels.ASB/DatatypeChannels.fs
+++ b/src/DatatypeChannels.ASB/DatatypeChannels.fs
@@ -12,13 +12,11 @@ module Channels =
     /// mkClient: function to construct the client.
     /// mkAdminClient: function to construct the admin client.
     /// log: function for diagnostics logging.
-    /// retries: number of send/receieve attempts.
     /// prefetch: optional prefetch limit.
     /// tempIdle: temporary queue idle lifetime.
     let mkNew (mkClient: unit -> ServiceBusClient)
               (mkAdminClient: unit -> ServiceBusAdministrationClient)
               (log: Log)
-              (retries: uint16)
               (prefetch: uint16 option)
               (tempIdle: TimeSpan) =
         let client = lazy mkClient()
@@ -31,13 +29,13 @@ module Channels =
                 let withBindings, receiveOptions, renew =
                     match source with
                     | Subscription binding ->
-                        let renew = Consumer.LockDuration.makeRenewable retries binding.Subscription.LockDuration
+                        let renew = Consumer.LockDuration.makeRenewable binding.Subscription.LockDuration
                         binding.Subscription.LockDuration <- min binding.Subscription.LockDuration Consumer.LockDuration.fiveMinutes
                         Subscription.withBinding log withAdminClient binding,
                         ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock),
                         renew
                     | Persistent (queueOptions, bindings) ->
-                        let renew = Consumer.LockDuration.makeRenewable retries queueOptions.LockDuration
+                        let renew = Consumer.LockDuration.makeRenewable queueOptions.LockDuration
                         queueOptions.LockDuration <- min queueOptions.LockDuration Consumer.LockDuration.fiveMinutes
                         Queue.withBindings log withAdminClient queueOptions bindings,
                         ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock),
@@ -51,19 +49,19 @@ module Channels =
                         ServiceBusReceiverOptions(ReceiveMode = ServiceBusReceiveMode.PeekLock, SubQueue = SubQueue.DeadLetter),
                         Consumer.LockDuration.noRenew
                 prefetch |> Option.iter (fun v -> receiveOptions.PrefetchCount <- int v)
-                Consumer.mkNew receiveOptions retries renew ofRecevied withClient withBindings
+                Consumer.mkNew receiveOptions renew ofRecevied withClient withBindings
 
             member __.GetPublisher<'msg> toSend (Topic topic) : Publisher<'msg> =
                 let sender = lazy client.Value.CreateSender topic
                 fun send -> send sender.Value
-                |> Publisher.mkNew retries toSend
+                |> Publisher.mkNew toSend
 
             member __.UsingPublisher<'msg> toSend (Topic topic) (cont:Publisher<'msg> -> Task<unit>) =
                 task {
                     let sender = client.Value.CreateSender topic
                     do!
                         fun send -> send sender
-                        |> Publisher.mkNew retries toSend
+                        |> Publisher.mkNew toSend
                         |> cont
                     do! sender.DisposeAsync()
                 }
@@ -76,10 +74,10 @@ module Channels =
     let fromFqdn (fqNamespace: string) (credential: Azure.Core.TokenCredential) (log: Log) =
         mkNew (fun _ -> ServiceBusClient(fqNamespace, credential))
               (fun _ -> ServiceBusAdministrationClient(fqNamespace, credential))
-              log 3us None (TimeSpan.FromMinutes 5.)
+              log None (TimeSpan.FromMinutes 5.)
 
     /// Build an instance using connection string
     let fromConnectionString (connString: string) (log: Log) =
         mkNew (fun _ -> ServiceBusClient connString)
               (fun _ -> ServiceBusAdministrationClient connString)
-              log 3us None (TimeSpan.FromMinutes 5.)
+              log None (TimeSpan.FromMinutes 5.)

--- a/src/DatatypeChannels.ASB/Prelude.fs
+++ b/src/DatatypeChannels.ASB/Prelude.fs
@@ -8,9 +8,6 @@ module Task =
     open System.Threading
     open System.Threading.Tasks
 
-    let private flattenExns (e: AggregateException) =
-        e.Flatten().InnerExceptions.[0]
-
     /// Convert `Task` to `Task<unit>`
     let ignore (t: Task) =
         task { return! t }
@@ -22,19 +19,6 @@ module Task =
     /// Monadic bind
     let bind (continuation: 'a -> Task<'b>) (t: Task<'a>) : Task<'b> =
         task { let! x = t in return! continuation x }
-        
-
-    /// Retry the task up to `n` times with progressive backoff
-    let withRetries (n: uint16) (mkTask: 'a -> Task<'r>) (arg: 'a) =
-        let rec mapResolved remaining (task: Task<'r>) =
-            match task.Status with
-            | TaskStatus.RanToCompletion -> Task.FromResult task.Result
-            | TaskStatus.Faulted when remaining > 0us ->
-                1000us * (n - remaining) |> int |> Task.Delay |> ignore |> bind (fun _ -> mkTask arg) |> mapResolved (remaining - 1us)
-            | TaskStatus.Faulted -> Task.FromException<'r> (flattenExns task.Exception)
-            | TaskStatus.Canceled -> Task.FromCanceled<'r> CancellationToken.None
-            | _ -> task.ContinueWith(mapResolved remaining).Unwrap()
-        mkTask arg |> mapResolved n
 
 module Assembly =
     open System.Runtime.CompilerServices

--- a/src/DatatypeChannels.ASB/Publisher.fs
+++ b/src/DatatypeChannels.ASB/Publisher.fs
@@ -2,11 +2,11 @@
 module DatatypeChannels.ASB.Publisher
 open Azure.Messaging.ServiceBus
 
-let internal mkNew retries (ToSend toSend) withSender =
+let internal mkNew (ToSend toSend) withSender =
     let send msg =
         fun (sender:ServiceBusSender) -> sender.SendMessageAsync msg |> Task.ignore
         |> withSender
-    toSend >> Task.withRetries retries send |> Publisher
+    toSend >> send |> Publisher
 
 /// Disassemble into primitives and send
 let publish (msg: 'msg) (Publisher publisher) = publisher msg


### PR DESCRIPTION
Retries are baked into the SDK and configurable via the client options, no need to have our own.