### PR TITLE
renew with active receiver, preserve messages across receivers

### DIFF
--- a/src/DatatypeChannels.ASB/Diagnostics.fs
+++ b/src/DatatypeChannels.ASB/Diagnostics.fs
@@ -2,8 +2,11 @@ module internal DatatypeChannels.ASB.Diagnostics
 
 open System.Diagnostics
 
+let formatName name : string =
+    $"DatatypeChannels.ASB.{name}"
+
 let mkActivitySource name : ActivitySource =
-    new ActivitySource($"DatatypeChannels.ASB.{name}")
+    new ActivitySource(formatName name)
 
 let createActivity name (kind: ActivityKind) (source: ActivitySource) : Activity =
     match source.CreateActivity(name, kind) with


### PR DESCRIPTION
Apparently received messages can be renewed on any instance of the receiver, so make an effort to preserve messages in flight and renew locks using the latest/active receiver.