### PR TITLE
tag release trigger

### DIFF
--- a/.github/workflows/azure.datatypechannels.asb.yml
+++ b/.github/workflows/azure.datatypechannels.asb.yml
@@ -3,7 +3,8 @@ on:
   push:
     branches:
     - master
-    - "refs/tags/*"
+    tags:
+    - "*"
   pull_request_target:
     branches:
     - master
@@ -14,6 +15,7 @@ permissions:
   contents: read
 jobs:
   build:
+    if: github.repository == 'Azure/DatatypeChannels.ASB'
     runs-on: ubuntu-latest
     environment: 
       name: build
@@ -38,7 +40,7 @@ jobs:
 
   release:
     needs: build
-    if: ${{ startsWith(github.ref, 'refs/tags') }}
+    if: github.repository == 'Azure/DatatypeChannels.ASB' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     environment: 
       name: release


### PR DESCRIPTION
- Conversion from ADO builds to github actions left the tag trigger defined incorrectly
- Disable actions triggering for forks
