### PR TITLE
fix: remove -s flag from release job to run full dependency chain

### DIFF
--- a/.github/workflows/azure.datatypechannels.asb.yml
+++ b/.github/workflows/azure.datatypechannels.asb.yml
@@ -54,4 +54,4 @@ jobs:
       env:
         NUGET_REPO_KEY: "${{ secrets.NUGET_REPO_KEY }}"
         NUGET_REPO_URL: "${{ vars.NUGET_REPO_URL }}"
-      run: dotnet fsi build.fsx -s -t release
+      run: dotnet fsi build.fsx -t release


### PR DESCRIPTION
Release stage don't share the file system, need all the build targets.