### PR TITLE
copy build artifacts out for release stage

### DIFF
--- a/.github/workflows/azure.datatypechannels.asb.yml
+++ b/.github/workflows/azure.datatypechannels.asb.yml
@@ -37,6 +37,11 @@ jobs:
       run: dotnet fsi build.fsx -t ci
       env:
         servicePrincipalId: ${{ secrets.CLIENT_ID }}
+    - name: Upload NuGet package
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget
+        path: out/*.nupkg
 
   release:
     needs: build
@@ -50,6 +55,11 @@ jobs:
     - uses: actions/setup-dotnet@v4.0.0
       with:
         global-json-file: global.json
+    - name: Download NuGet package
+      uses: actions/download-artifact@v4
+      with:
+        name: nuget
+        path: out
     - name: Publish
       env:
         NUGET_REPO_KEY: "${{ secrets.NUGET_REPO_KEY }}"

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,9 @@ packages/
 
 .fake
 .farmer
-/output
-temp/
+output/
 tmp/
+out/
 *.user
 local.settings.json
 

--- a/build.fsx
+++ b/build.fsx
@@ -143,6 +143,8 @@ Target.create "test" (fun _ ->
 Target.create "package" (fun _ ->
     let args = sprintf "/p:Version=%s --no-restore" ver.AsString
     DotNet.pack (fun a -> a.WithCommon (fun c -> { c with CustomParams = Some args })) "."
+    !! "src/DatatypeChannels.ASB/bin/Release/*.nupkg"
+    |> Shell.copyFiles "out"
 )
 
 Target.create "publish" (fun _ ->
@@ -152,7 +154,7 @@ Target.create "publish" (fun _ ->
                        "DatatypeChannels.ASB" ver.AsString
                        (Environment.environVar "NUGET_REPO_URL")
                        (Environment.environVar "NUGET_REPO_KEY")
-    let result = exec ("src/DatatypeChannels.ASB/bin/Release") "nuget" args
+    let result = exec "out" "nuget" args
     if (not result.OK) then failwithf "%A" result.Errors
 )
 
@@ -226,16 +228,17 @@ Target.create "ci" ignore
   ==> "build"
   ==> "test"
   ==> "generateDocs"
+
+"build"
   ==> "package"
-  ==> "publish"
 
 "releaseDocs"
   <== ["test"; "generateDocs" ]
 
 "release"
-  <== [ "initCI"; "publish" ]
+  <== [ "publish" ]
 
 "ci"
-  <== [ "initCI"; "test" ]
+  <== [ "initCI"; "test"; "package" ]
 
 Target.runOrDefaultWithArguments "test"


### PR DESCRIPTION
Release stage does not have access to test resources, copy the artifacts from stage to stage instead.